### PR TITLE
ignore dead key event

### DIFF
--- a/WLTerminalView.m
+++ b/WLTerminalView.m
@@ -592,8 +592,13 @@ BOOL isEnglishNumberAlphabet(unsigned char c) {
 
 - (void)keyDown:(NSEvent *)theEvent {
     [[self frontMostConnection] resetMessageCount];
+    
+    if (theEvent.characters.length == 0) {
+        // dead key pressed
+        return;
+    }
 	
-    unichar c = [[theEvent characters] characterAtIndex:0];
+    unichar c = [theEvent.characters characterAtIndex:0];
 	// URL
 	if(_isInUrlMode) {
 		BOOL shouldExit;
@@ -629,8 +634,8 @@ BOOL isEnglishNumberAlphabet(unsigned char c) {
 
     WLTerminal *ds = [self frontMostTerminal];
 
-    if (([theEvent modifierFlags] & NSControlKeyMask) &&
-	   (([theEvent modifierFlags] & NSAlternateKeyMask) == 0 )) {
+    if ((theEvent.modifierFlags & NSControlKeyMask) &&
+	   ((theEvent.modifierFlags & NSAlternateKeyMask) == 0 )) {
         buf[0] = c;
         [[self frontMostConnection] sendBytes:buf length:1];
         return;


### PR DESCRIPTION
- do not crash on a dead key event

if i try to input some roman character with accent, welly crashes. this patch address this problem by by-passing these events.
